### PR TITLE
Update example base64 encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,9 @@ steps:
 **Note: The input `APP_PEM` needs to be base64 encoded.**  You can encode your private key file like this from the terminal:
 
 ```
-cat your_app_key.pem | base64
+cat your_app_key.pem | base64 -w 0 && echo
 ```
+*The base64 encoded string must be on a single line, so be sure to remove any linebreaks when creating `APP_PEM` in your project's GitHub secrets.*
 
 ## Mandatory Inputs
 


### PR DESCRIPTION
The current base64 encoding example includes base64's default line wrapping, but the GitHub secret `APP_PEM` expects the string to be on a single line.

I've updated the README to explain this, and also updated the example command.

`-w 0` specifies no linewrapping for base64.
`&& echo` adds a single newline to the end of the command output to move the terminal command prompt to the next line.